### PR TITLE
restore mistakenly removed F2.config

### DIFF
--- a/config/F2.config
+++ b/config/F2.config
@@ -1,0 +1,29 @@
+// Other processes after create_IndelCandidate_SAMtools will only run one at a time, so
+// we don't need to control their resources.
+// The configuration below forces processes to run one at a time by needing
+// the total memory available on a lowmem node.
+
+process {
+    withName: run_validate_PipeVal {
+        cpus = 1
+        memory = 1.GB
+    }
+    withName: call_sSNV_SomaticSniper {
+        cpus = 1
+        memory = 3.GB
+    }
+    withName: convert_BAM2Pileup_SAMtools {
+        cpus = 1
+        memory = 3.GB
+    }
+    withName: create_IndelCandidate_SAMtools {
+        cpus = 1
+        memory = 3.GB
+    }
+    withName: call_sIndel_Manta {
+        cpus = 2
+    }
+    withName: call_sSNV_Strelka2 {
+        cpus = 2
+    }
+}


### PR DESCRIPTION
# Description
I accidentally removed `config/F2.config` with PR #136 (closed).  I was hoping to restore it with this PR, but on testing it doesn't work.   I compared the F2.config file location and file contents with an earlier branch (https://github.com/uclahs-cds/pipeline-call-sSNV/tree/maotian-add-contamination) and made sure they were identical. 

Error message:
```
Error executing process > 'mutect2:call_sSNVInNonAssembledChromosomes_Mutect2'

Caused by:
  Cannot invoke method minus() on null object -- Check script '/hot/user/sfitzgibbon/git/pipeline-call-sSNV/./module/./mutect2-processes.nf' at line: 177

Source block:
  tumors = tumor.collect { "-I '$it'" }.join(' ')
  normals = normal.collect { "-I '$it'" }.join(' ')
  normal_names = normal_name.collect { "-normal ${it}" }.join(' ')
  bam = params.tumor_only_mode ? "$tumors" : "$tumors $normals $normal_names"
  germline = params.germline ? "-germline-resource $germline_resource_gnomad_vcf" : ""
  """
      set -euo pipefail
  
      gatk --java-options \"-Xmx${(task.memory - params.gatk_command_mem_diff).getMega()}m\" Mutect2 \
          -R $reference \
          -XL $interval \
          $bam \
          --f1r2-tar-gz ${params.output_filename}_unfiltered-non-canonical-f1r2.tar.gz \
          -O ${params.output_filename}_unfiltered-non-canonical.vcf.gz \
          --tmp-dir \$PWD \
          $germline \
          ${params.mutect2_extra_args}
      """
```

Line 177 is 
```
 gatk --java-options \"-Xmx${(task.memory - params.gatk_command_mem_diff).getMega()}m\" Mutect2 \
```
so maybe task.memory is not being set?  The F2.config file is much shorter than the other F$x.config files.

## Testing Results

- Tumor/Normal Paired Sample:
    - sample:  TWGSAMIN000001
    - input YAML: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/unreleased/sfitz-restore-F2.config/a-mini.yml
    - config:    /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/unreleased/sfitz-restore-F2.config/a-mini.config
    - output:    /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/unreleased/sfitz-restore-F2.config/output.F2.sc12
    - log:  /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/unreleased/sfitz-restore-F2.config/TWGSAMIN000001.log



# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have reviewed the [Nextflow pipeline standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=Nextflow+pipeline+standardization).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request; I am listed already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [ ] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] I have tested the pipeline on at least one A-mini sample.
