### PR TITLE
correcting the changelog with fixed release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+
+## [6.0.0-rc.1] - 2023-02-08
 ### Changed
 - Update `README`: add Pipeline Steps and Tool descriptions
-
-## [6.0.0-rc.1] - 2023-1-30
-### Changed
 - Update to use `set_resources_allocation` from pipeline-Nextflow-config repo
 - Update SAMtools to v1.16.1
 - Switch Docker Hub images to GitHub packages.


### PR DESCRIPTION
# Description
I realized after redoing the v6.0.0-rc.1 release that the changelog was no longer correct.  Fixed here.

