### PR TITLE
Sfitz remove common checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Test CODEOWNERS
 # Default owner(s)
-*	@tyamaguchi-ucla @yashpatel6 @maotian06 @sorelfitzgibbon @uclahs-cds/nextflow-wg
+*	@tyamaguchi-ucla @yashpatel6 @maotian06 @sorelfitzgibbon @ucla-cds/nextflow-wg
 # Folder specific owner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+resource limit check now from submodule
+
 ## [7.0.0] - 2023-10-18
 
 ### Changed

--- a/config/base.config
+++ b/config/base.config
@@ -1,19 +1,19 @@
 process {
-    cpus = { methods.check_max( 1 * task.attempt, 'cpus' ) }
+    cpus = { methods.check_limits( 1 * task.attempt, 'cpus' ) }
 
     errorStrategy = { task.exitStatus in [143, 137, 104, 134, 139] ? 'retry' : 'finish' }
     maxRetries = 1
 
     withLabel:process_low {
-        cpus = { methods.check_max( 2 * task.attempt, 'cpus' ) }
-        memory = { methods.check_max( 3.GB * task.attempt, 'memory' ) }
+        cpus = { methods.check_limits( 2 * task.attempt, 'cpus' ) }
+        memory = { methods.check_limits( 3.GB * task.attempt, 'memory' ) }
     }
     withLabel:process_medium {
-        cpus = { methods.check_max( 6 * task.attempt, 'cpus' ) }
-        memory = { methods.check_max( 42.GB * task.attempt, 'memory' ) }
+        cpus = { methods.check_limits( 6 * task.attempt, 'cpus' ) }
+        memory = { methods.check_limits( 42.GB * task.attempt, 'memory' ) }
     }
     withLabel:process_high {
-        cpus = { methods.check_max(12 * task.attempt, 'cpus' ) }
-        memory = { methods.check_max( 84.GB * task.attempt, 'memory' ) }
+        cpus = { methods.check_limits(12 * task.attempt, 'cpus' ) }
+        memory = { methods.check_limits( 84.GB * task.attempt, 'memory' ) }
     }
 }

--- a/config/methods.config
+++ b/config/methods.config
@@ -9,76 +9,6 @@ methods {
         process.cache = params.cache_intermediate_pipeline_steps
     }
 
-    // Function to ensure that resource requirements don't go beyond
-    // a maximum limit
-    check_max = { obj, type ->
-        if (type == 'memory') {
-            try {
-                if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
-                    return params.max_memory as nextflow.util.MemoryUnit
-                else
-                    return obj
-            } catch (all) {
-                println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
-                return obj
-            }
-        } else if (type == 'time') {
-            try {
-                if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
-                    return params.max_time as nextflow.util.Duration
-                else
-                    return obj
-            } catch (all) {
-                println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
-                return obj
-            }
-        } else if (type == 'cpus') {
-            try {
-                return Math.min(obj, params.max_cpus as int)
-            } catch (all) {
-                println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
-                return obj
-            }
-        }
-    }
-
-    // Function to ensure that resource requirements don't go beyond
-    // a maximum limit or below a minimum limit
-    check_limits = { obj, type ->
-        if (type == 'memory') {
-            try {
-                if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
-                    return params.max_memory as nextflow.util.MemoryUnit
-                else if (obj.compareTo(params.min_memory as nextflow.util.MemoryUnit) == -1)
-                    return params.min_memory as nextflow.util.MemoryUnit
-                else
-                    return obj
-            } catch (all) {
-                println "   ### WARNING ###   Max memory '${params.max_memory}' or min memory '${params.min_memory}' is not valid! Using default value: $obj"
-                return obj
-            }
-        } else if (type == 'time') {
-            try {
-                if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
-                    return params.max_time as nextflow.util.Duration
-                else if (obj.compareTo(params.min_time as nextflow.util.Duration) == -1)
-                    return params.min_time as nextflow.util.Duration
-                else
-                    return obj
-            } catch (all) {
-                println "   ### WARNING ###   Max time '${params.max_time}' or min time '${params.min_time}' is not valid! Using default value: $obj"
-                return obj
-            }
-        } else if (type == 'cpus') {
-            try {
-                return Math.max( Math.min( obj, params.max_cpus as int ), params.min_cpus as int )
-            } catch (all) {
-                println "   ### WARNING ###   Max cpus '${params.max_cpus}' or min cpus '${params.min_cpus}' is not valid! Using default value: $obj"
-                return obj
-            }
-        }
-    }
-
     set_sample_params = {
         params.multi_tumor_sample = false
         params.multi_normal_sample = false
@@ -143,6 +73,7 @@ methods {
         params.output_dir_base = "${params.output_dir}/${manifest.name}-${manifest.version}/${params.sample_id}"
         params.log_output_dir = "${params.output_dir_base}/log-${manifest.name}-${manifest.version}-${date}"
     }
+
     set_pipeline_log = {
         trace.enabled = true
         trace.file = "${params.log_output_dir}/nextflow-log/trace.txt"
@@ -153,6 +84,7 @@ methods {
         report.enabled = true
         report.file = "${params.log_output_dir}/nextflow-log/report.html"
     }
+
     check_valid_algorithms = {
         Set valid_algorithms = ['somaticsniper', 'strelka2', 'mutect2', 'muse']
         if (params.tumor_only_mode || params.multi_tumor_sample || params.multi_normal_sample ) {
@@ -168,6 +100,7 @@ methods {
             }
         }
     }
+
     modify_base_allocations = {
         if (!(params.containsKey('base_resource_update') && params.base_resource_update)) {
             return


### PR DESCRIPTION
# Description
 - Removed `check_max` and `check_limits` in methods.config.  Changed calls to `check_max` to `check_limits` (external).
 - update submodules


## Testing Results
`nftest run a_mini-muse`
output: `/hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/unreleased/sfitz-remove-common-checks/a_mini-muse`

NFTest asserts fail because `Expect` files have been updated based on the unmerged extract-sample-name branch

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request; I am listed already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample.
