### PR TITLE
Grant specific permissions to Nextflow tests workflow

### DIFF
--- a/.github/workflows/nextflow-tests.yaml
+++ b/.github/workflows/nextflow-tests.yaml
@@ -1,5 +1,5 @@
 ---
-name: Nextflow Tests
+name: Nextflow
 
 on:
   push:
@@ -14,6 +14,8 @@ permissions:
   pull-requests: write
   # Required so dependabot can autofix changes
   contents: write
+  # Required until the docker image is made public
+  packages: read
 
 jobs:
   tests:

--- a/.github/workflows/nextflow-tests.yaml
+++ b/.github/workflows/nextflow-tests.yaml
@@ -9,6 +9,12 @@ on:
     branches:
       - main
 
+permissions:
+  # Required so dependabot can post review comments
+  pull-requests: write
+  # Required so dependabot can autofix changes
+  contents: write
+
 jobs:
   tests:
     uses: uclahs-cds/tool-Nextflow-action/.github/workflows/nextflow-tests.yml@main

--- a/.github/workflows/slashcommand.yml
+++ b/.github/workflows/slashcommand.yml
@@ -1,0 +1,18 @@
+# https://github.com/peter-evans/slash-command-dispatch/blob/a1f5efae7cc1f6c46ef1d02b5ce4710c716907aa/.github/workflows/slash-command-dispatch.yml
+---
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  # These are the same permissions listed in the nextflow-tests.yml workflow
+  pull-requests: write
+  contents: write
+  packages: read
+
+jobs:
+  slashCommandDispatch:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/fix-tests') }}
+    uses: uclahs-cds/tool-Nextflow-action/.github/workflows/nextflow-tests.yml@main
+    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add workflow to build and publish documentation to GitHub Pages
 - Add workflow to run Nextflow configuration regression tests
 - Add one regression test
+- Add workflow to respond to "/fix-tests" comments
 
 ### Fixed
 - Grant explicit permissions for Nextflow configuration test workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add workflow to run Nextflow configuration regression tests
 - Add one regression test
 
+### Fixed
+- Grant explicit permissions for Nextflow configuration test workflow
+
 ## [8.0.0] - 2024-01-29
 
 ### Changed


### PR DESCRIPTION
It turns out that, regardless of the repository's default settings for workflow permissions, any workflows triggered by dependabot are [limited to read-only](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions).

That means that, by default, dependabot PRs like #279 cannot use the fancy new `/fix-tests` comment from https://github.com/uclahs-cds/tool-Nextflow-action/pull/29.

This change explicitly adds in the required permissions for that workflow:
* `content: write` for [pushing new commits](https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#usage)
* `pull-requests: write` for [creating reviews](https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#create-a-review-for-a-pull-request--fine-grained-access-tokens)
  * Also needed to [list existing reviews](https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#list-reviews-for-a-pull-request--fine-grained-access-tokens)
  * Also needed to [react to a comment with 🚀](https://docs.github.com/en/rest/reactions/reactions?apiVersion=2022-11-28#create-reaction-for-an-issue-comment--fine-grained-access-tokens)
* `packages: read` to access the [docker image](https://github.com/uclahs-cds/tool-Nextflow-action/pkgs/container/nextflow-config-tests) (we should just make that public)

This PR also completes the integration from https://github.com/uclahs-cds/tool-Nextflow-action/pull/29 by including another workflow that responds to "/fix-tests" comments and automatically fixes any testing problems. This workflow has the exact same permissions as the original.

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request; I am listed already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the pipeline on at least one A-mini sample.
