### PR TITLE
update M64 resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Nextflow configuration test workflows
 
 ### Changed
+- Update M64 resource allocations
 - Update resource allocations
 
 ## [8.0.0] - 2024-01-29

--- a/config/M64.config
+++ b/config/M64.config
@@ -9,27 +9,27 @@ process {
     if (params.input_type == 'bam') {
         withName: call_sSNV_SomaticSniper {
             cpus = 1
-            memory = 4.GB
+            memory = 20.GB
             retry_strategy {
                 memory {
                     strategy = 'add'
-                    operand = 5.GB
+                    operand = 20.GB
                 }
             }
         }
         withName: convert_BAM2Pileup_SAMtools {
             cpus = 1
-            memory = 16.GB
+            memory = 30.GB
             retry_strategy {
                 memory {
                     strategy = 'add'
-                    operand = 16.GB
+                    operand = 30.GB
                 }
             }
         }
         withName: create_IndelCandidate_SAMtools {
             cpus = 1
-            memory = 2.GB
+            memory = 10.GB
             retry_strategy {
                 memory {
                     strategy = 'add'
@@ -39,41 +39,41 @@ process {
         }
         withName: call_sIndel_Manta {
             cpus = 8
-            memory = 12.GB
+            memory = 10.GB
             retry_strategy {
                 memory {
                     strategy = 'add'
-                    operand = 12.GB
+                    operand = 10.GB
                 }
             }
         }
         withName: call_sSNV_Strelka2 {
             cpus = 28
-            memory = 24.GB
+            memory = 30.GB
             retry_strategy {
                 memory {
                     strategy = 'add'
-                    operand = 12.GB
+                    operand = 30.GB
                 }
             }
         }
         withName: call_sSNV_Mutect2 {
             cpus = 1
-            memory = 10.GB
+            memory = 30.GB
             retry_strategy {
                 memory {
                     strategy = 'add'
-                    operand = 24.GB
+                    operand = 30.GB
                 }
             }
         }
         withName: run_LearnReadOrientationModel_GATK {
             cpus = 1
-            memory = 24.GB
+            memory = 30.GB
             retry_strategy {
                 memory {
                     strategy = 'add'
-                    operand = 12.GB
+                    operand = 30.GB
                 }
             }
         }
@@ -83,17 +83,17 @@ process {
             retry_strategy {
                 memory {
                     strategy = 'add'
-                    operand = 40.GB
+                    operand = 60.GB
                 }
             }
         }
         withName: run_sump_MuSE {
             cpus = 6
-            memory = 28.GB
+            memory = 40.GB
             retry_strategy {
                 memory {
                     strategy = 'add'
-                    operand = 24.GB
+                    operand = 20.GB
                 }
             }
         }

--- a/config/M64.config
+++ b/config/M64.config
@@ -19,11 +19,11 @@ process {
         }
         withName: convert_BAM2Pileup_SAMtools {
             cpus = 1
-            memory = 30.GB
+            memory = 100.GB
             retry_strategy {
                 memory {
                     strategy = 'add'
-                    operand = 30.GB
+                    operand = 100.GB
                 }
             }
         }
@@ -34,6 +34,16 @@ process {
                 memory {
                     strategy = 'add'
                     operand = 10.GB
+                }
+            }
+        }
+        withName: generate_ReadCount_bam_readcount {
+            cpus = 1
+            memory = 20.GB
+            retry_strategy {
+                memory {
+                    strategy = 'add'
+                    operand = 20.GB
                 }
             }
         }

--- a/config/M64.config
+++ b/config/M64.config
@@ -8,73 +8,91 @@ process {
     }
     withName: call_sSNV_SomaticSniper {
         cpus = 1
-        memory = 316.GB
-    }
-    withName: convert_BAM2Pileup_SAMtools {
-        cpus = 1
-        memory = 316.GB
-    }
-    withName: create_IndelCandidate_SAMtools {
-        cpus = 1
-        memory = 316.GB
-    }
-    withName: call_sIndel_Manta {
-        cpus = 36
-        memory = 15.GB
+        memory = 4.GB
         retry_strategy {
             memory {
                 strategy = 'add'
                 operand = 5.GB
+            }
+        }
+    }
+    withName: convert_BAM2Pileup_SAMtools {
+        cpus = 1
+        memory = 16.GB
+        retry_strategy {
+            memory {
+                strategy = 'add'
+                operand = 16.GB
+            }
+        }
+    }
+    withName: create_IndelCandidate_SAMtools {
+        cpus = 1
+        memory = 2.GB
+        retry_strategy {
+            memory {
+                strategy = 'add'
+                operand = 10.GB
+            }
+        }
+    }
+    withName: call_sIndel_Manta {
+        cpus = 8
+        memory = 12.GB
+        retry_strategy {
+            memory {
+                strategy = 'add'
+                operand = 12.GB
             }
         }
     }
     withName: call_sSNV_Strelka2 {
-        cpus = 36
-        memory = 10.GB
+        cpus = 28
+        memory = 24.GB
         retry_strategy {
             memory {
                 strategy = 'add'
-                operand = 5.GB
+                operand = 12.GB
             }
         }
     }
     withName: call_sSNV_Mutect2 {
-        cpus = 2
-        memory = 5.GB
+        cpus = 1
+        memory = 10.GB
         retry_strategy {
             memory {
                 strategy = 'add'
-                operand = 5.GB
+                operand = 24.GB
             }
         }
     }
     withName: run_LearnReadOrientationModel_GATK {
-        cpus = 4
-        memory = 8.GB
+        cpus = 1
+        memory = 24.GB
         retry_strategy {
             memory {
-                strategy = 'exponential'
-                operand = 2
+                strategy = 'add'
+                operand = 12.GB
             }
         }
     }
     withName: call_sSNV_MuSE {
         cpus = 16
-        memory = 128.GB
+        memory = 120.GB
         retry_strategy {
             memory {
                 strategy = 'add'
-                operand = 10.GB
+                operand = 40.GB
             }
         }
     }
     withName: run_sump_MuSE {
-        cpus = 2
-        memory = 128.GB
+        cpus = 6
+        memory = 28.GB
         retry_strategy {
             memory {
                 strategy = 'add'
-                operand = 10.GB
+                operand = 24.GB
             }
         }
     }


### PR DESCRIPTION
# Description
Updated `M64.config` resource allocations based on results of large sample runs described [here](https://github.com/uclahs-cds/pipeline-call-sSNV/issues/288)

### Closes #...

## Testing Results
Because this is geared towards running very large samples which can take close to 2 weeks to run, I don't want to test this branch on anything that doesn't need to be run.  I don't have any appropriate samples.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request; I am listed already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the pipeline on at least one A-mini sample.
