### PR TITLE
add storing of parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Output pipeline parameters to log directory using `store_object_as_json`
 - Add `panel_of_normals_vcf` for MuTect2.
 - Add `a_mini-all-tools-vcf-input` to `nftest`
 - Add option to input VCFs for intersection

--- a/config/methods.config
+++ b/config/methods.config
@@ -4,6 +4,7 @@ includeConfig "${projectDir}/external/pipeline-Nextflow-config/config/schema/sch
 includeConfig "${projectDir}/external/pipeline-Nextflow-config/config/retry/retry.config"
 includeConfig "${projectDir}/external/pipeline-Nextflow-config/config/methods/common_methods.config"
 includeConfig "${projectDir}/external/pipeline-Nextflow-config/config/bam/bam_parser.config"
+includeConfig "${projectDir}/external/pipeline-Nextflow-config/config/store_object_as_json/store_object_as_json.config"
 
 methods {
     set_process = {
@@ -152,5 +153,9 @@ methods {
         methods.set_intersect_regions_params()
         methods.set_pipeline_log()
         methods.setup_docker_cpus()
+        json_extractor.store_object_as_json( // must be last
+            params,
+            new File("${params.log_output_dir}/nextflow-log/params.json")
+        )
     }
 }


### PR DESCRIPTION
# Description
Uses the new store_object_as_json method from https://github.com/uclahs-cds/pipeline-Nextflow-config/pull/43 to store the pipeline's parameters in ${params.log_output_dir}/nextflow-log/params.json.

The parameters from my test run were successfully saved to:
`/hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/unreleased/sfitz-store-parameters/a_mini-all-tools-std-input/call-sSNV-8.1.0/S2-v1.1.5/log-call-sSNV-8.1.0-20241010T194927Z/nextflow-log/params.json`

### Closes #307 

## Testing Results
NFTest
/hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/unreleased/sfitz-store-parameters/log-nftest-20241010T194919Z.log
cases: a_mini-all-tools-std-inpu


# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request; I am listed already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample.
