### PR TITLE
fix check for panel of normals and add in log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add option to input VCFs for intersection
 - Add VAF stripplot for variant overlaps across tools
 
+### Fixed
+ - Avoid warning when run without panel of normals
+
 ## [8.1.0] - 2024-05-15
 
 ### Added

--- a/config/methods.config
+++ b/config/methods.config
@@ -92,6 +92,9 @@ methods {
             params.germline = false
         }
         params.germline_resource_gnomad_vcf_index = "${params.germline_resource_gnomad_vcf}.tbi"
+        if (!params.containsKey("panel_of_normals_vcf")) {
+            params.panel_of_normals_vcf = ""
+        }
     }
 
     check_valid_algorithms = {

--- a/module/mutect2-processes.nf
+++ b/module/mutect2-processes.nf
@@ -15,6 +15,7 @@ Mutect2 Options:
 - single tumor normal pair:       ${params.single_NT_paired}
 - germline resource:              ${params.germline_resource_gnomad_vcf}
 - contamination_table:            ${params.input.tumor.contamination_table}
+- panel of normals:               ${params.panel_of_normals_vcf}
 """
 
 process run_SplitIntervals_GATK {
@@ -92,7 +93,7 @@ process call_sSNV_Mutect2 {
     normal_names = normal_name.collect { "-normal ${it}" }.join(' ')
     bam = normal_names == '-normal NO_ID' ? "$tumors" : "$tumors $normals $normal_names"
     germline = params.germline ? "--germline-resource $germline_resource_gnomad_vcf" : ""
-    panel_of_normals = params.panel_of_normals_vcf ? "--panel-of-normals ${params.panel_of_normals_vcf}" : ""
+    panel_of_normals_cmd = params.panel_of_normals_vcf ? "--panel-of-normals ${params.panel_of_normals_vcf}" : ""
     interval_id = interval.baseName.split('-')[0]
     """
     set -euo pipefail
@@ -105,7 +106,7 @@ process call_sSNV_Mutect2 {
         -O ${params.output_filename}_unfiltered-${interval.baseName}.vcf.gz \
         --tmp-dir \$PWD \
         $germline \
-        $panel_of_normals \
+        $panel_of_normals_cmd \
         ${params.mutect2_extra_args}
     """
     }

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -118,6 +118,7 @@
       "normal_id": "0192847",
       "output_dir": "/tmp/outputs",
       "output_dir_base": "/tmp/outputs/call-sSNV-VER.SI.ON/0192847",
+      "panel_of_normals_vcf": "",
       "patient_id": "TWGSAMIN000001",
       "pipeval_version": "4.0.0-rc.2",
       "proc_resource_params": {

--- a/test/configtest-F32.json
+++ b/test/configtest-F32.json
@@ -118,6 +118,7 @@
       "normal_id": "0192847",
       "output_dir": "/tmp/outputs",
       "output_dir_base": "/tmp/outputs/call-sSNV-VER.SI.ON/0192847",
+      "panel_of_normals_vcf": "",
       "patient_id": "TWGSAMIN000001",
       "pipeval_version": "4.0.0-rc.2",
       "proc_resource_params": {


### PR DESCRIPTION
# Description
Running without a panel of normals was triggering a warning.   This fixes that and adds the specified panel of normals to the Mutect2 log output.

### Closes #308

## Testing Results
### without panel of normals
NFTest a_mini-all-tools-std-input
`/hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/unreleased/sfitz-fix-pon-check/log-nftest-20241025T230650Z.log`

### with panel of normals
config: `/hot/code/sfitzgibbon/GitHub/uclahs-cds/pipeline-call-sSNV/test/config/untracked/a_mini-all-tools-pon.config`
yaml: `/hot/code/sfitzgibbon/GitHub/uclahs-cds/pipeline-call-sSNV/test/yaml/a_mini_n2-std-input.yaml`
log: `/hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/unreleased/sfitz-fix-pon-check/slurm-230914.out`

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request; I am listed already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample.
