### PR TITLE
Sfitz fix single tool runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Update NFTest paths
+- Fix single tool run logic
 - Update PipeVal 4.0.0-rc.2 -> 5.1.0
 - Update GATK 4.5.0.0 -> 4.6.1.0
 - Update bam_readcount 0.8.0 -> 1.0.1

--- a/main.nf
+++ b/main.nf
@@ -251,23 +251,25 @@ workflow {
         process_vcfs.out.idx.set { tool_indices }
         }
 
-    intersect(
-        tool_gzvcfs,
-        tool_indices,
-        script_dir_ch,
-        )
+    if (params.algorithm.size() > 1 || params.input_type == 'vcf') {
+        intersect(
+            tool_gzvcfs,
+            tool_indices,
+            script_dir_ch,
+            )
 
-    all_files = tool_gzvcfs.mix(tool_indices)
-        .flatten()
-        .collect()
+        all_files = tool_gzvcfs.mix(tool_indices)
+            .flatten()
+            .collect()
 
-    identified_gzvcfs = tool_gzvcfs.flatten()
-        .map{ [algorithm: getToolName(it), path: it] }
-        .collect()
+        identified_gzvcfs = tool_gzvcfs.flatten()
+            .map{ [algorithm: getToolName(it), path: it] }
+            .collect()
 
-    plot_vaf(
-        identified_gzvcfs,
-        all_files
-        )
+        plot_vaf(
+            identified_gzvcfs,
+            all_files
+            )
 
+        }
     }

--- a/main.nf
+++ b/main.nf
@@ -232,19 +232,18 @@ workflow {
             mutect2.out.gzvcf.set { mutect2_gzvcf_ch }
             mutect2.out.idx.set { mutect2_idx_ch }
             }
-        // Intersect all vcf files
-        if (params.algorithm.size() > 1) {
-            tool_gzvcfs = (somaticsniper_gzvcf_ch
-                .mix(strelka2_gzvcf_ch)
-                .mix(mutect2_gzvcf_ch)
-                .mix(muse_gzvcf_ch))
-                .collect()
-            tool_indices = (somaticsniper_idx_ch
-                .mix(strelka2_idx_ch)
-                .mix(mutect2_idx_ch)
-                .mix(muse_idx_ch))
-                .collect()
-            }
+
+        tool_gzvcfs = (somaticsniper_gzvcf_ch
+            .mix(strelka2_gzvcf_ch)
+            .mix(mutect2_gzvcf_ch)
+            .mix(muse_gzvcf_ch))
+            .collect()
+        tool_indices = (somaticsniper_idx_ch
+            .mix(strelka2_idx_ch)
+            .mix(mutect2_idx_ch)
+            .mix(muse_idx_ch))
+            .collect()
+
     } else if (params.input_type == 'vcf') {
         process_vcfs(samplesToProcess_ch)
         process_vcfs.out.gzvcf.set { tool_gzvcfs }
@@ -257,19 +256,19 @@ workflow {
             tool_indices,
             script_dir_ch,
             )
-
-        all_files = tool_gzvcfs.mix(tool_indices)
-            .flatten()
-            .collect()
-
-        identified_gzvcfs = tool_gzvcfs.flatten()
-            .map{ [algorithm: getToolName(it), path: it] }
-            .collect()
-
-        plot_vaf(
-            identified_gzvcfs,
-            all_files
-            )
-
         }
+
+    all_files = tool_gzvcfs.mix(tool_indices)
+        .flatten()
+        .collect()
+
+    identified_gzvcfs = tool_gzvcfs.flatten()
+        .map{ [algorithm: getToolName(it), path: it] }
+        .collect()
+
+    plot_vaf(
+        identified_gzvcfs,
+        all_files
+        )
+
     }

--- a/nftest.yml
+++ b/nftest.yml
@@ -91,15 +91,15 @@ cases:
     verbose: true
     asserts:
       - actual: call-sSNV-*/S2-v1.1.5/Mutect2-*/output/Mutect2-*_TWGSAMIN_S2-v1.1.5_Indel.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-mutect2-tumor-only/Mutect2-4.4.0.0_TWGSAMIN_S2-v1.1.5_Indel.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-mutect2-tumor-only/Mutect2-4.6.1.0_TWGSAMIN_S2-v1.1.5_Indel.vcf.gz
         script: test/assert_vcf.sh
 
       - actual: call-sSNV-*/S2-v1.1.5/Mutect2-*/output/Mutect2-*_TWGSAMIN_S2-v1.1.5_MNV.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-mutect2-tumor-only/Mutect2-4.4.0.0_TWGSAMIN_S2-v1.1.5_MNV.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-mutect2-tumor-only/Mutect2-4.6.1.0_TWGSAMIN_S2-v1.1.5_MNV.vcf.gz
         script: test/assert_vcf.sh
 
       - actual: call-sSNV-*/S2-v1.1.5/Mutect2-*/output/Mutect2-*_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-mutect2-tumor-only/Mutect2-4.4.0.0_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-mutect2-tumor-only/Mutect2-4.6.1.0_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
         script: test/assert_vcf.sh
 
   - name: a_mini-mutect2-multiple-samples
@@ -119,7 +119,7 @@ cases:
         script: test/assert_vcf.sh
 
       - actual: call-sSNV-*/TWGSAMIN000001/Mutect2-*/output/Mutect2-*_TWGSAMIN_TWGSAMIN000001_SNV.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-mutect2-multiple-samples/Mutect2-4.4.0.0_TWGSAMIN_TWGSAMIN000001_SNV.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-mutect2-multiple-samples/Mutect2-4.6.1.0_TWGSAMIN_TWGSAMIN000001_SNV.vcf.gz
         script: test/assert_vcf.sh
 
   - name: a_mini-two-tools
@@ -179,7 +179,7 @@ cases:
     verbose: true
     asserts:
       - actual: call-sSNV-*/S2-v1.1.5/SomaticSniper-*/output/SomaticSniper-*_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-somaticsniper/S2-v1.1.5/SomaticSniper-1.0.5.0/SomaticSniper-1.0.5.0_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/SomaticSniper-1.0.5.0_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
         script: test/assert_vcf.sh
 
   - name: a_mini-strelka2
@@ -215,7 +215,7 @@ cases:
         script: test/assert_vcf.sh
 
       - actual: call-sSNV-*/S2-v1.1.5/Mutect2-*/output/Mutect2-*_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/Mutect2-4.4.0.0_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/Mutect2-4.6.1.0_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
         script: test/assert_vcf.sh
 
   - name: a_mini-muse

--- a/nftest.yml
+++ b/nftest.yml
@@ -91,15 +91,15 @@ cases:
     verbose: true
     asserts:
       - actual: call-sSNV-*/S2-v1.1.5/Mutect2-*/output/Mutect2-*_TWGSAMIN_S2-v1.1.5_Indel.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/Mutect2-4.4.0.0_TWGSAMIN_S2-v1.1.5_Indel.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-mutect2-tumor-only/Mutect2-4.4.0.0_TWGSAMIN_S2-v1.1.5_Indel.vcf.gz
         script: test/assert_vcf.sh
 
       - actual: call-sSNV-*/S2-v1.1.5/Mutect2-*/output/Mutect2-*_TWGSAMIN_S2-v1.1.5_MNV.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/Mutect2-4.4.0.0_TWGSAMIN_S2-v1.1.5_MNV.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-mutect2-tumor-only/Mutect2-4.4.0.0_TWGSAMIN_S2-v1.1.5_MNV.vcf.gz
         script: test/assert_vcf.sh
 
       - actual: call-sSNV-*/S2-v1.1.5/Mutect2-*/output/Mutect2-*_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/Mutect2-4.6.1.0_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-mutect2-tumor-only/Mutect2-4.4.0.0_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
         script: test/assert_vcf.sh
 
   - name: a_mini-mutect2-multiple-samples
@@ -111,15 +111,15 @@ cases:
     verbose: true
     asserts:
       - actual: call-sSNV-*/TWGSAMIN000001/Mutect2-*/output/Mutect2-*_TWGSAMIN_TWGSAMIN000001_Indel.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/Mutect2-4.4.4.0_TWGSAMIN_TWGSAMIN000001_Indel.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-mutect2-multiple-samples/Mutect2-4.4.0.0_TWGSAMIN_TWGSAMIN000001_Indel.vcf.gz
         script: test/assert_vcf.sh
 
       - actual: call-sSNV-*/TWGSAMIN000001/Mutect2-*/output/Mutect2-*_TWGSAMIN_TWGSAMIN000001_MNV.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/Mutect2-4.4.0.0_TWGSAMIN_TWGSAMIN000001_MNV.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-mutect2-multiple-samples/Mutect2-4.4.0.0_TWGSAMIN_TWGSAMIN000001_MNV.vcf.gz
         script: test/assert_vcf.sh
 
       - actual: call-sSNV-*/TWGSAMIN000001/Mutect2-*/output/Mutect2-*_TWGSAMIN_TWGSAMIN000001_SNV.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/Mutect2-4.6.1.0_TWGSAMIN_TWGSAMIN000001_SNV.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-mutect2-multiple-samples/Mutect2-4.4.0.0_TWGSAMIN_TWGSAMIN000001_SNV.vcf.gz
         script: test/assert_vcf.sh
 
   - name: a_mini-two-tools
@@ -143,31 +143,31 @@ cases:
         script: test/assert_vcf.sh
 
       - actual: call-sSNV-*/S2-v1.1.5/Intersect-BCFtools-*/output/BCFtools-*_TWGSAMIN_S2-v1.1.5_SNV-concat.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/BCFtools-1.17_TWGSAMIN_S2-v1.1.5_SNV-concat.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-two-tools/Intersect-BCFtools/BCFtools-1.17_TWGSAMIN_S2-v1.1.5_SNV-concat.vcf.gz
         script: test/assert_vcf.sh
 
       - actual: call-sSNV-*/S2-v1.1.5/Intersect-BCFtools-*/output/BCFtools-*_TWGSAMIN_S2-v1.1.5_SNV-concat.maf.bz2
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/BCFtools-1.17_TWGSAMIN_S2-v1.1.5_SNV-concat.maf.bz2
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-two-tools/Intersect-BCFtools/BCFtools-1.17_TWGSAMIN_S2-v1.1.5_SNV-concat.maf.bz2
         method: md5
 
       - actual: call-sSNV-*/S2-v1.1.5/Intersect-BCFtools-*/output/BCFtools-*_TWGSAMIN_S2-v1.1.5_Venn-diagram.tiff
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/BCFtools-1.17_TWGSAMIN_S2-v1.1.5_Venn-diagram.tiff
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-two-tools/Intersect-BCFtools/BCFtools-1.17_TWGSAMIN_S2-v1.1.5_Venn-diagram.tiff
         method: md5
 
       - actual: call-sSNV-*/S2-v1.1.5/Intersect-BCFtools-*/output/isec-1-or-more/BCFtools-*_TWGSAMIN_S2-v1.1.5_sites.txt
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/isec-1-or-more/BCFtools-1.17_TWGSAMIN_S2-v1.1.5_sites.txt
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-two-tools/Intersect-BCFtools/isec-1-or-more/BCFtools-1.17_TWGSAMIN_S2-v1.1.5_sites.txt
         method: md5
 
       - actual: call-sSNV-*/S2-v1.1.5/Intersect-BCFtools-*/output/isec-2-or-more/BCFtools-*_TWGSAMIN_S2-v1.1.5_sites.txt
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/isec-2-or-more/BCFtools-1.17_TWGSAMIN_S2-v1.1.5_sites.txt
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-two-tools/Intersect-BCFtools/isec-2-or-more/BCFtools-1.17_TWGSAMIN_S2-v1.1.5_sites.txt
         method: md5
 
       - actual: call-sSNV-*/S2-v1.1.5/Intersect-BCFtools-*/output/SomaticSniper-*_TWGSAMIN_S2-v1.1.5_SNV-intersect.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/SomaticSniper-1.0.5.0_TWGSAMIN_S2-v1.1.5_SNV-intersect.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-two-tools/Intersect-BCFtools/SomaticSniper-1.0.5.0_TWGSAMIN_S2-v1.1.5_SNV-intersect.vcf.gz
         script: test/assert_vcf.sh
 
       - actual: call-sSNV-*/S2-v1.1.5/Intersect-BCFtools-*/output/Strelka2-*_TWGSAMIN_S2-v1.1.5_SNV-intersect.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/Strelka2-2.9.10_TWGSAMIN_S2-v1.1.5_SNV-intersect.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-two-tools/Intersect-BCFtools/Strelka2-2.9.10_TWGSAMIN_S2-v1.1.5_SNV-intersect.vcf.gz
         script: test/assert_vcf.sh
 
   - name: a_mini-somaticsniper
@@ -179,7 +179,7 @@ cases:
     verbose: true
     asserts:
       - actual: call-sSNV-*/S2-v1.1.5/SomaticSniper-*/output/SomaticSniper-*_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/SomaticSniper-1.0.5.0_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/a_mini-somaticsniper/S2-v1.1.5/SomaticSniper-1.0.5.0/SomaticSniper-1.0.5.0_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
         script: test/assert_vcf.sh
 
   - name: a_mini-strelka2
@@ -215,7 +215,7 @@ cases:
         script: test/assert_vcf.sh
 
       - actual: call-sSNV-*/S2-v1.1.5/Mutect2-*/output/Mutect2-*_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/Mutect2-4.6.1.0_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/Mutect2-4.4.0.0_TWGSAMIN_S2-v1.1.5_SNV.vcf.gz
         script: test/assert_vcf.sh
 
   - name: a_mini-muse
@@ -263,7 +263,7 @@ cases:
         script: test/assert_vcf.sh
 
       - actual: call-sSNV-*/S2-v1.1.5/Intersect-BCFtools-*/output/Mutect2-*_TWGSAMIN_S2-v1.1.5_SNV-intersect.vcf.gz
-        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/Mutect2-4.4.0.0_TWGSAMIN_S2-v1.1.5_SNV-intersect.vcf.gz
+        expect: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-output/Mutect2-4.6.1.0_TWGSAMIN_S2-v1.1.5_SNV-intersect.vcf.gz
         script: test/assert_vcf.sh
 
       - actual: call-sSNV-*/S2-v1.1.5/Intersect-BCFtools-*/output/SomaticSniper-*_TWGSAMIN_S2-v1.1.5_SNV-intersect.vcf.gz

--- a/test/yaml/a_mini-vcf.yaml
+++ b/test/yaml/a_mini-vcf.yaml
@@ -5,6 +5,6 @@ input_tumor_id: 'S2_v1.1.5' # tumor ID in the VCF files must match this or 'TUMO
 input_normal_id: 'HG002.N' # normal ID in the VCF files must match this or 'NORMAL'
 input:
   muse: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-input/MuSE-2.0.4_TWGSAMIN_S2-v1.1.5_SNV-pass.vcf.gz
-  mutect2: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-input/Mutect2-4.5.0.0_TWGSAMIN_S2-v1.1.5_all-pass.vcf.gz
+  mutect2: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-input/Mutect2-4.6.1.0_TWGSAMIN_S2-v1.1.5_all-pass.vcf.gz
   somaticsniper: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-input/SomaticSniper-1.0.5.0_TWGSAMIN_S2-v1.1.5_hc.vcf.gz
   strelka2: /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/test-input/Strelka2-2.9.10_TWGSAMIN_S2-v1.1.5_SNV-pass.vcf.gz


### PR DESCRIPTION
# Description
 - Since the addition of the workflow for VCF input, the workflow selection logic was broken leading to pipeline failure if a single sSNV caller was requested.  This is now fixed.
 - NFTest paths were updated to finish accommodation of new tool versions and to simplify and remove redundant paths to equivalent files.  


### Closes #313

## Testing Results
- NFTest
    - output:   /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/8.1.0/sfitz-fix-single-tool-runs
    - logs:       /hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/8.1.0/sfitz-fix-single-tool-runs/log*
    - cases:  
        - a_mini-all-tools-std-input
        - a_mini-all-tools-vcf-input
        - a_mini-somaticsniper
        - a_mini-strelka2
        - a_mini-mutect2
        - a_mini-muse
        - a_mini-mutect2-multiple-samples
        - a_mini-mutect2-tumor-only


# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample.
