### PR TITLE
fix divide by zero VAF calculation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Key changes to Strelka2 and SomaticSniper VAF calculations
 - Switch to generalized resource handling
 - Update NFTest paths
 - Fix single tool run logic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Key changes to Strelka2 and SomaticSniper VAF calculations
+- Avoid VAF divide by zero error
 - Switch to generalized resource handling
 - Update NFTest paths
 - Fix single tool run logic

--- a/script/prepare-VAFs.py
+++ b/script/prepare-VAFs.py
@@ -236,3 +236,4 @@ def main() -> None:
 
 if __name__=='__main__':
     main()
+

--- a/script/prepare-VAFs.py
+++ b/script/prepare-VAFs.py
@@ -93,69 +93,41 @@ def validate_args(opts: argparse.Namespace) -> None:
 
     validate_output_dir(opts.output_dir)
 
-def get_vaf_strelka2(variant: dict, sample: str) -> float:
+def get_vaf_strelka2(variant: dict, sample: str) -> Tuple[int, int]:
     """ Calculate read count for Strelka2 format """
     sample_index = variant.samples.index(sample)
-    
-    # Use tier 1 counts (index [0]) as recommended by Strelka developers
     ref_base = variant.REF.strip(' ') + 'U'
-    alt_base = str(variant.ALT[0]).strip(' ') + 'U'
-    
     ref_reads = int(variant.samples[sample_index][ref_base][0])
-    alt_reads = int(variant.samples[sample_index][alt_base][0])
+    # pylint: disable=R1728
+    # Take alternate allele with most number of reads as the ALT
+    alt_reads = max([int(variant.samples[sample_index][allele.sequence + 'U'][0]) \
+        for allele in variant.ALT])
     total_reads = ref_reads + alt_reads
-    
     if total_reads == 0:
-        return 0.0
+        return 0
     return alt_reads/total_reads
 
-def get_vaf_somaticsniper(variant: dict, sample: str) -> float:
+def get_vaf_somaticsniper(variant: dict, sample: str) -> Tuple[int, int]:
     """ Calculate read count for SomaticSniper format """
+    # using DP4
     sample_index = variant.samples.index(sample)
-    
-    # Prefer BCOUNT over DP4 for better accuracy if available
-    try:
-        bcount = variant.samples[sample_index]["BCOUNT"]
-        if len(bcount) >= 4:
-            ref_base = variant.REF.upper()
-            alt_base = str(variant.ALT[0]).upper()
-            base_map = {'A': 0, 'C': 1, 'G': 2, 'T': 3}
-            
-            ref_reads = int(bcount[base_map.get(ref_base, 0)])
-            alt_reads = int(bcount[base_map.get(alt_base, 0)])
-            total_reads = sum(int(x) for x in bcount)
-            
-            if total_reads == 0:
-                return 0.0
-            return alt_reads / total_reads
-    except (KeyError, AttributeError):
-        pass
-    
-    # Fallback to DP4
     ref_reads = int(variant.samples[sample_index]["DP4"][0]) \
         + int(variant.samples[sample_index]["DP4"][1])
     alt_reads = int(variant.samples[sample_index]["DP4"][2]) \
         + int(variant.samples[sample_index]["DP4"][3])
     total_reads = ref_reads + alt_reads
-    
     if total_reads == 0:
-        return 0.0
+        return 0
     return alt_reads/total_reads
 
-def get_vaf_mutect2(variant: dict, sample: str) -> float:
+def get_vaf_mutect2(variant: dict, sample: str) -> Tuple[int, int]:
     """ Calculate read count for Mutect2 format """
     sample_index = variant.samples.index(sample)
-    ad = variant.samples[sample_index]["AD"]
-    
-    if len(ad) < 2:
-        return 0.0
-        
-    ref_reads = int(ad[0])
-    alt_reads = int(ad[1])
+    ref_reads = int(variant.samples[sample_index]["AD"][0])
+    alt_reads = int(variant.samples[sample_index]["AD"][1])
     total_reads = ref_reads + alt_reads
-
     if total_reads == 0:
-        return 0.0
+        return 0
     return alt_reads/total_reads
 
 def does_variant_pass(variant: dict) -> bool:
@@ -180,7 +152,7 @@ def calculate_adjusted_vaf(sample_id: str, variant: dict, purity: float) -> floa
 
     if 'AD' in variant_data_keys:
         raw_vaf = get_vaf_mutect2(variant, sample)
-    elif 'DP4' in variant_data_keys or 'BCOUNT' in variant_data_keys:
+    elif 'DP4' in variant_data_keys:
         raw_vaf = get_vaf_somaticsniper(variant, sample)
     elif all(base+'U' in variant_data_keys for base in ['A', 'C', 'G', 'T']):
         raw_vaf = get_vaf_strelka2(variant, sample)

--- a/script/prepare-VAFs.py
+++ b/script/prepare-VAFs.py
@@ -236,4 +236,3 @@ def main() -> None:
 
 if __name__=='__main__':
     main()
-


### PR DESCRIPTION
# Description
Avoid divide by zero errors in VCF calcluations.

#### Details
The pipeline was [erroring out with a divide by zero error on Strelka input VCFs](https://github.com/uclahs-cds/pipeline-call-sSNV/issues/345).  This is due to the use of only tier 1 alternate variant allele counts, as recommended by Strelka authors (https://github.com/Illumina/strelka/tree/v2.9.x/docs/userGuide#somatic-variant-allele-frequencies), which can occasionally lead to a [zero alt allele count](https://github.com/hartwigmedical/hmftools/issues/54).  It’s not clear whether using tier 2 reads would give more comparable VAFs to other callers or not.  It seems likely the stringency in other callers is between Strelka’s tier 1 and tier 2.  

More discussion here (https://github.com/Illumina/strelka/issues/87).

### Closes #345

## Testing Results
<!-- Delete unused cases below. Usually NFTest is desired and sufficient -->
- Case 1
    - sample:    BE-1-RP5, from @graceooh's [issue](https://github.com/uclahs-cds/pipeline-call-sSNV/issues/345)
    - input yaml: `/hot/user/jieunoh/gap6_pilot/metapipeline_input_after_top_up/project_1A/intersect_call_ssnv/yaml_dir/BE-1-RP5.yaml`
    - config:     `/hot/user/jieunoh/gap6_pilot/metapipeline_input_after_top_up/project_1A/intersect_call_ssnv/template.config`
    - log:    `/hot/code/sfitzgibbon/GitHub/uclahs-cds/pipeline-call-sSNV/slurm-330272.out`

- NFTest
    - output:    `/hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/8.2.0/sfitz-fix-plot-vaf/a_mini-all-tools-std-input`
    - log:     `/hot/software/pipeline/pipeline-call-sSNV/Nextflow/development/8.2.0/sfitz-fix-plot-vaf/log-nftest-20250604T193805Z.log`
    - cases:    `a_mini-all-tools-std-input`
    - 
# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample.
