### PR TITLE
give convert_BAM2Pileup 5G

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update BCFtools 1.17 -> 1.21
 - Update NFtest for new tool versions
 - Set VAF plot y-limit based on max adjusted VAF
+- Increase convert_BAM2Pileup memory allocation
 
 ### Fixed
 

--- a/config/resources.json
+++ b/config/resources.json
@@ -1277,9 +1277,9 @@
                 "max": 1
             },
             "memory": {
-                "min": "1 GB",
-                "fraction": 0.01,
-                "max": "2 GB"
+                "min": "3 GB",
+                "fraction": 0.04,
+                "max": "8 GB"
             },
             "retry_strategy": {
                 "memory": {

--- a/config/resources.json
+++ b/config/resources.json
@@ -818,7 +818,7 @@
             },
             "memory": {
                 "min": "5 GB",
-                "fraction": 0.07,
+                "fraction": 0.35,
                 "max": "5 GB"
             },
             "retry_strategy": {

--- a/config/resources.json
+++ b/config/resources.json
@@ -817,9 +817,9 @@
                 "max": 1
             },
             "memory": {
-                "min": "2 GB",
-                "fraction": 0.01,
-                "max": "2 GB"
+                "min": "5 GB",
+                "fraction": 0.07,
+                "max": "5 GB"
             },
             "retry_strategy": {
                 "memory": {


### PR DESCRIPTION
# Description
22 out of 149 (15%) of recent `call-sSNV` runs had out of memory errors for `somaticsniper:convert_BAM2Pileup_SAMtool`.  They all worked on automatic retry.  The initial (failed) runs took an average of `1 hr 47 min`.  Looking at the `trace.txt` files, all but one used less than `5 GB` in the successful retry and that one was barely over and might have worked with `5 GB`.  

I haven't tested it because it doesn't seem worth running it on an F72.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the pipeline on at least one A-mini sample.
